### PR TITLE
Don't compile Float80 extensions on arm64 (addresses #1)

### DIFF
--- a/Sources/GfxMath/FloatingPointGenericMath.swift
+++ b/Sources/GfxMath/FloatingPointGenericMath.swift
@@ -10,7 +10,7 @@ public protocol FloatingPointGenericMath : FloatingPoint {
   // ...
 }
 
-#if os(Linux) || os(macOS)
+#if !arch(arm64) && (os(Linux) || os(macOS))
 extension Float80 : FloatingPointGenericMath {
   public static func _log(_ x: Float80) -> Float80 { return log(x) }
   public static func _sin(_ x: Float80) -> Float80 { return sin(x) }


### PR DESCRIPTION
`Float80` isn't available on Apple Silicon, which means that the library currently doesn't compile on Apple Silicon. This PR modifies the compilation condition to include a check for Apple Silicon. This addresses #1 