### PR TITLE
Fix compilation warnings and an infinite loop

### DIFF
--- a/Sources/GfxMath/Color/Experimental/EColorFormatFpRGB.swift
+++ b/Sources/GfxMath/Color/Experimental/EColorFormatFpRGB.swift
@@ -21,11 +21,11 @@ extension FpRGBColor {
         Color(UInt8(max(0, min(255, r * 255))), UInt8(max(0, min(255, g * 255))), UInt8(max(0, min(255, b * 255))), 255)
     }
 
-    public func toIRGB<D>() -> IRGBColor<D> {
+    public func toIRGB<D2: BinaryInteger>() -> IRGBColor<D2> {
         IRGBColor(
-            r: D(max(0, min(255, r * 255))),
-            g: D(max(0, min(255, g * 255))),
-            b: D(max(0, min(255, b * 255)))
+            r: D2(max(0, min(255, r * 255))),
+            g: D2(max(0, min(255, g * 255))),
+            b: D2(max(0, min(255, b * 255)))
         )
     }
 

--- a/Sources/GfxMath/Color/Experimental/EColorFormatFpRGBA.swift
+++ b/Sources/GfxMath/Color/Experimental/EColorFormatFpRGBA.swift
@@ -25,12 +25,12 @@ extension FpRGBAColor {
         Color(UInt8(max(0, min(255, r * 255))), UInt8(max(0, min(255, g * 255))), UInt8(max(0, min(255, b * 255))), UInt8(max(0, min(255, a * 255))))
     }
 
-    public func toIRGBA<D>() -> IRGBAColor<D> {
+    public func toIRGBA<D2: BinaryInteger>() -> IRGBAColor<D2> {
         IRGBAColor(
-            r: D(max(0, min(255, r * 255))),
-            g: D(max(0, min(255, g * 255))),
-            b: D(max(0, min(255, b * 255))),
-            a: D(max(0, min(255, a * 255)))
+            r: D2(max(0, min(255, r * 255))),
+            g: D2(max(0, min(255, g * 255))),
+            b: D2(max(0, min(255, b * 255))),
+            a: D2(max(0, min(255, a * 255)))
         )
     }
 

--- a/Sources/GfxMath/Matrix.swift
+++ b/Sources/GfxMath/Matrix.swift
@@ -1,7 +1,6 @@
 import Foundation
 
-public protocol MatrixProtocol: Sequence, Equatable, CustomStringConvertible, Hashable {
-    associatedtype Element: Numeric
+public protocol MatrixProtocol: Sequence, Equatable, CustomStringConvertible, Hashable where Element: Numeric {
     var rows: Int { get }
     var cols: Int { get }
     var elements: [Element] { get set }
@@ -42,7 +41,7 @@ public extension MatrixProtocol {
     }
 
     // TODO: there might be a more efficient way to transpose
-    @inlinable public var transposed: Self {
+    @inlinable var transposed: Self {
         var matrix = clone() // TODO: maybe have some clone function that does not clone elements
        
         for rIndex in 0..<self.rows {
@@ -261,8 +260,7 @@ public protocol Matrix4Protocol: MatrixProtocol {
 }
 
 public extension Matrix4Protocol {
-
-    public init<M3: Matrix3Protocol>(topLeft: M3, rest: Self = .identity) where M3.Element == Element {
+    init<M3: Matrix3Protocol>(topLeft: M3, rest: Self = .identity) where M3.Element == Element {
         self.init([
             topLeft[0, 0], topLeft[0, 1], topLeft[0, 2], rest[0, 3],
             topLeft[1, 0], topLeft[1, 1], topLeft[1, 2], rest[1, 3],
@@ -375,8 +373,8 @@ public extension Matrix4Protocol where Element: FloatingPointGenericMath {
     }
 
     // TODO: the following functions might be specific to openGL, maybe put those in the GLGraphicsMath package
-    @inlinable static func viewTransformation<V: Vector3Protocol>(up: V, right: V, front: V, translation: V) -> Self where V.Element == Self.Element {
-        return try! Self([
+    @inlinable static func viewTransformation<V: Vector3Protocol>(up: V, right: V, front: V, translation: V) -> Self where V.Element == Self.Element, V.Dimension == Dim_3x1 {
+        return Self([
             right.x, right.y, right.z, 0,
             up.x, up.y, up.z, 0,
             front.x, front.y, front.z, 0,
@@ -435,7 +433,7 @@ public struct Matrix4<E: Numeric & Hashable>: Matrix4Protocol {
 
 // TODO: might replace this or remove this / current function of this is to simply remove throws
 @inlinable public func * <E: Numeric>(lhs: Matrix4<E>, rhs: Matrix4<E>) -> Matrix4<E> {
-    return try! lhs.matmul(rhs)
+    return lhs.matmul(rhs)
 }
 
 public typealias FMat4 = Matrix4<Float>

--- a/Sources/GfxMath/Size.swift
+++ b/Sources/GfxMath/Size.swift
@@ -25,6 +25,7 @@ extension Size2Protocol {
 }
 
 public struct Size2<E: Numeric & Hashable>: Size2Protocol {
+  public typealias Dimension = Dim_2x1
   public typealias Element = E
   public let rows: Int = 2
   public let cols: Int = 1

--- a/Sources/GfxMath/Transform.swift
+++ b/Sources/GfxMath/Transform.swift
@@ -21,9 +21,9 @@ public enum DTransform2 {
 
   public func transform(size: DSize2) -> DSize2 {
     switch self {
-    case let .translate(translation):
+    case .translate(_):
       return size
-    case let .scale(scale, origin):
+    case let .scale(scale, _):
       return size * scale.abs()
     }
   }

--- a/Sources/GfxMath/geometry/Line.swift
+++ b/Sources/GfxMath/geometry/Line.swift
@@ -30,7 +30,7 @@ public extension LineProtocol {
     }
 
     var debugDescription: String {
-        "LineProtocol x = (\(point)) + scale * (\(direction))"
+        "LineProtocol x = (\(origin)) + scale * (\(direction))"
     }
 
     var point: VectorProtocol {
@@ -45,7 +45,7 @@ public extension LineProtocol {
     }
 
     func pointAt(scale: VectorProtocol.Element) -> VectorProtocol {
-        return point + direction * scale
+        return origin + direction * scale
     }
 
     /// - Parameter point: A point on the line.
@@ -54,11 +54,11 @@ public extension LineProtocol {
         for axis in 0..<direction.count {
             if direction[axis] == 0 {
                 // TODO: maybe need accuracy here too
-                if abs(self.point[axis] - point[axis]) > accuracy {
+                if abs(self.origin[axis] - origin[axis]) > accuracy {
                     return nil
                 }
             } else {
-                let scale = (point[axis] - self.point[axis]) / direction[axis]
+                let scale = (origin[axis] - self.origin[axis]) / direction[axis]
                 if lastScale == nil {
                     lastScale = scale
                 } else if abs(scale - lastScale!) > accuracy {
@@ -95,7 +95,7 @@ public extension LineProtocol {
     }
 }
 
-public extension LineProtocol where VectorProtocol: Vector2Protocol {
+public extension LineProtocol where VectorProtocol: Vector2Protocol, VectorProtocol.Dimension == Dim_2x1 {
     // TODO: what to return on identical
     /// - Returns: nil if parallel, self.point when identical, intersection point if intersecting
     func intersect<O: LineProtocol>(line otherLine: O) -> VectorProtocol? where O.VectorProtocol == VectorProtocol {
@@ -106,16 +106,16 @@ public extension LineProtocol where VectorProtocol: Vector2Protocol {
         
         // TODO: which value to use as accuracy?
         if slope1 == slope2 || abs(slope1 - slope2) < VectorProtocol.Element(0.1) {
-            if contains(otherLine.point) {
-                return point
+            if contains(otherLine.origin) {
+                return origin
             } else {
                 return nil
             }
         }
         
-        let scale1 = (otherLine.point - self.point).cross(otherLine.direction) / self.direction.cross(otherLine.direction)
+        let scale1 = (otherLine.origin - self.origin).cross(otherLine.direction) / self.direction.cross(otherLine.direction)
 
-        return pointAtScale(scale1)
+        return pointAt(scale: scale1)
     }
 }
 
@@ -125,8 +125,8 @@ public extension LineProtocol where VectorProtocol: Vector3Protocol {
             return nil
         }
 
-        let s = (plane.elevation - plane.normal.dot(point)) / (plane.normal.dot(direction))
-        return pointAtScale(s)
+        let s = (plane.elevation - plane.normal.dot(origin)) / (plane.normal.dot(direction))
+        return pointAt(scale: s)
     }
 }
 

--- a/Sources/GfxMath/geometry/LineSegment.swift
+++ b/Sources/GfxMath/geometry/LineSegment.swift
@@ -4,18 +4,18 @@ public struct LineSegment<V: VectorProtocol> where V.Element: BinaryFloatingPoin
   public var scaleMin: Vector.Element
   public var scaleMax: Vector.Element
   public var start: Vector {
-    line.pointAtScale(scaleMin)
+    line.pointAt(scale: scaleMin)
   }
   public var end: Vector {
-    line.pointAtScale(scaleMax)
+    line.pointAt(scale: scaleMax)
   }
   public var length: Vector.Element {
     (start - end).length
   }
 
-  public var line: AnyLine<Vector>
+  public var line: Line<Vector>
 
-  public init(line: AnyLine<Vector>, scaleMin: Vector.Element, scaleMax: Vector.Element) {
+  public init(line: Line<Vector>, scaleMin: Vector.Element, scaleMax: Vector.Element) {
     var scaleMin = scaleMin
     var scaleMax = scaleMax
 
@@ -31,9 +31,9 @@ public struct LineSegment<V: VectorProtocol> where V.Element: BinaryFloatingPoin
   }
 
   public init(start: Vector, end: Vector) {
-    let line = AnyLine(from: start, to: end)
-    var scaleMin = line.scaleAt(start)!
-    var scaleMax = line.scaleAt(end)!
+    let line = Line(from: start, to: end)
+    let scaleMin = line.scaleAt(start)!
+    let scaleMax = line.scaleAt(end)!
     self.init(line: line, scaleMin: scaleMin, scaleMax: scaleMax)
   }
 }

--- a/Sources/GfxMath/geometry/Plane.swift
+++ b/Sources/GfxMath/geometry/Plane.swift
@@ -13,7 +13,7 @@ public extension Plane where VectorProtocol.Element: FloatingPoint {
         }
     }
 
-    public init(point: VectorProtocol, normal: VectorProtocol) {
+    init(point: VectorProtocol, normal: VectorProtocol) {
         self.init()
         self.point = point
         self.normal = normal.normalized()

--- a/Sources/GfxMath/geometry/Rect.swift
+++ b/Sources/GfxMath/geometry/Rect.swift
@@ -128,8 +128,8 @@ extension Rect where Data: FloatingPoint {
         var minScale = -Data.infinity
         var maxScale = Data.infinity
         for dimension in 0..<2 {
-            var newMinScale = (min[dimension] - line.point[dimension]) / line.direction[dimension]
-            var newMaxScale = (max[dimension] - line.point[dimension]) / line.direction[dimension]
+            var newMinScale = (min[dimension] - line.origin[dimension]) / line.direction[dimension]
+            var newMaxScale = (max[dimension] - line.origin[dimension]) / line.direction[dimension]
             if newMinScale > newMaxScale {
                 let tmp = newMinScale
                 newMinScale = newMaxScale
@@ -143,7 +143,7 @@ extension Rect where Data: FloatingPoint {
             }
         }
 
-        return (min: Vector2<Data>(line.pointAtScale(minScale)), max: Vector2<Data>(line.pointAtScale(maxScale)))
+        return (min: Vector2<Data>(line.pointAt(scale: minScale)), max: Vector2<Data>(line.pointAt(scale: maxScale)))
     }
 }
 

--- a/Sources/GfxMath/geometry/Triangle.swift
+++ b/Sources/GfxMath/geometry/Triangle.swift
@@ -34,7 +34,7 @@ public struct Triangle<V: VectorProtocol> {
   }
 }
 
-extension Triangle where V: Vector2Protocol, V.Element: BinaryFloatingPoint {
+extension Triangle where V: Vector2Protocol, V.Element: BinaryFloatingPoint, V.Dimension == Dim_2x1 {
   public var area: V.Element {
     let v1 = vertexB - vertexA
     let v2 = vertexC - vertexA

--- a/Sources/GfxMath/vector/Vector.swift
+++ b/Sources/GfxMath/vector/Vector.swift
@@ -24,9 +24,7 @@ public protocol Vector2Protocol: VectorProtocol {
   var y: Element { get set }
 }
 
-extension Vector2Protocol {
-  public typealias Dimension = Dim_2x1
-
+extension Vector2Protocol where Dimension == Vector2<Element>.Dimension {
   @inlinable public static var zero: Self {
     Self([0, 0])
   }
@@ -75,6 +73,7 @@ where Element: BinaryFloatingPoint, Element.RawSignificand: FixedWidthInteger {
 }
 
 public struct Vector2<E: Numeric & Hashable>: Vector2Protocol {
+  public typealias Dimension = Dim_2x1
   public typealias Element = E
   public let rows: Int = 2
   public let cols: Int = 1
@@ -97,9 +96,7 @@ public protocol Vector3Protocol: VectorProtocol {
 
 }
 
-extension Vector3Protocol {
-  public typealias Dimension = Dim_3x1
-
+extension Vector3Protocol where Dimension == Vector3<Element>.Dimension {
   @inlinable public static var zero: Self {
     Self([0, 0, 0])
   }
@@ -148,6 +145,7 @@ extension Vector3Protocol {
 }
 
 public struct Vector3<E: Numeric & Hashable>: Vector3Protocol {
+  public typealias Dimension = Dim_3x1
   public typealias Element = E
   public let rows: Int = 3
   public let cols: Int = 1
@@ -170,9 +168,7 @@ public protocol Vector4Protocol: VectorProtocol {
 
 }
 
-extension Vector4Protocol {
-  public typealias Dimension = Dim_4x1
-
+extension Vector4Protocol where Dimension == Vector4<Element>.Dimension {
   @inlinable public static var zero: Self {
     Self([0, 0, 0, 0])
   }
@@ -219,6 +215,7 @@ extension Vector4Protocol {
 }
 
 public struct Vector4<E: Numeric & Hashable>: Vector4Protocol {
+  public typealias Dimension = Dim_4x1
   public typealias Element = E
   public let rows: Int = 4
   public let cols: Int = 1
@@ -237,11 +234,12 @@ public struct Vector4<E: Numeric & Hashable>: Vector4Protocol {
   }
 }
 
-extension Matrix4Protocol {
-  @inlinable public static func matmul<VectorProtocol: Vector4Protocol>(_ other: VectorProtocol)
+extension Matrix4Protocol where Element: Hashable {
+  @inlinable public func matmul<VectorProtocol: Vector4Protocol>(_ other: VectorProtocol)
     -> VectorProtocol where Self.Element == VectorProtocol.Element
   {
-    return VectorProtocol(try! self.matmul(other).elements)
+    let result: Matrix<Element> = self.matmul(other)
+    return VectorProtocol(result.elements)
   }
 }
 

--- a/Sources/GfxMath/vector/VectorProtocol+Operators.swift
+++ b/Sources/GfxMath/vector/VectorProtocol+Operators.swift
@@ -202,7 +202,7 @@ extension VectorProtocol where Element: FloatingPoint {
   }
 }
 
-extension Vector3Protocol where Element: FloatingPointGenericMath {
+extension Vector3Protocol where Element: FloatingPointGenericMath, Dimension == Dim_3x1 {
   /// - Returns 0 to pi (positive only)
   @inlinable public func absAngle(to otherVector: Self) -> Element {
     let angle = acos(normalized().dot(otherVector.normalized()))


### PR DESCRIPTION
The project has a pretty significant number of build warnings when building with the current version of Swift (some of which are going to become errors in Swift 6). This PR addresses all build warnings; one of which was about a `matmul` function which would cause an infinite loop if called (just had to add explicit typing to break the infinite loop).

The tests still compile and pass.